### PR TITLE
Restricting SPARQL update

### DIFF
--- a/jena-fuseki/shiro.ini
+++ b/jena-fuseki/shiro.ini
@@ -37,6 +37,9 @@ admin=pw
 ## and the rest are restricted
 /$/** = authcBasic,user[admin]
 
+## Sparql update is restricted
+/*/update/** = authcBasic,user[admin]
+
 
 ## If you want simple, basic authentication user/password
 ## on the operations,


### PR DESCRIPTION
Allowing everyone to add and remove all data doesn't seem to be a reasonable default.