### PR TITLE
Convert environment variables to datasets at fuseki startup

### DIFF
--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -17,7 +17,7 @@
 #FROM alpine:3.4
 #RUN apk add --update openjdk8-jre pwgen bash wget ca-certificates && rm -rf /var/cache/apk/*
 FROM java:8-jre-alpine
-RUN apk add --update pwgen bash wget ca-certificates && rm -rf /var/cache/apk/*
+RUN apk add --update pwgen bash curl ca-certificates && rm -rf /var/cache/apk/*
 
 MAINTAINER Stian Soiland-Reyes <stain@apache.org>
 
@@ -44,8 +44,8 @@ WORKDIR /tmp
 # sha512 checksum
 RUN echo "$FUSEKI_SHA512  fuseki.tar.gz" > fuseki.tar.gz.sha512
 # Download/check/unpack/move in one go (to reduce image size)
-RUN     wget -O fuseki.tar.gz $FUSEKI_MIRROR/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz || \
-        wget -O fuseki.tar.gz $FUSEKI_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz && \
+RUN     curl $FUSEKI_MIRROR/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz > fuseki.tar.gz || \
+        curl $FUSEKI_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz > fuseki.tar.gz && \
         sha512sum -c fuseki.tar.gz.sha512 && \
         tar zxf fuseki.tar.gz && \
         mv apache-jena-fuseki* $FUSEKI_HOME && \

--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -114,6 +114,13 @@ volume `fuseki-data` as recommended above, do:
     docker rm fuseki
     docker run -d --name fuseki -p 3030:3030 --volumes-from fuseki-data stain/jena-fuseki
 
+## Create empty datasets
+
+Tou can create empty datasets at startup with:
+
+    docker run -d --name fuseki -p 3030:3030 -e FUSEKI_DATASET1=mydataset -e FUSEKI_DATASET_2=otherdataset stain/jena-fuseki
+
+This will create 2 empty datasets: mydataset and otherdataset.
 
 ## Data loading
 

--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -116,7 +116,7 @@ volume `fuseki-data` as recommended above, do:
 
 ## Create empty datasets
 
-Tou can create empty datasets at startup with:
+You can create empty datasets at startup with:
 
     docker run -d --name fuseki -p 3030:3030 -e FUSEKI_DATASET1=mydataset -e FUSEKI_DATASET_2=otherdataset stain/jena-fuseki
 

--- a/jena-fuseki/docker-entrypoint.sh
+++ b/jena-fuseki/docker-entrypoint.sh
@@ -37,4 +37,21 @@ if [ -n "$ADMIN_PASSWORD" ] ; then
   sed -i "s/^admin=.*/admin=$ADMIN_PASSWORD/" "$FUSEKI_BASE/shiro.ini"
 fi
 
-exec "$@"
+exec "$@" &
+
+# Wait until server is up
+while [[ $(curl -I http://localhost:3030 2>/dev/null | head -n 1 | cut -d$' ' -f2) != '200' ]]; do
+  sleep 1s
+done
+
+# Convert env to datasets
+printenv | egrep "^FUSEKI_DATASET_" | while read env_var
+do
+    dataset=$(echo $env_var | egrep -o "=.*$" | sed 's/^=//g')
+    curl -s 'http://localhost:3030/$/datasets'\
+         -H "Authorization: Basic $(echo -n admin:${ADMIN_PASSWORD} | base64)" \
+         -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8'\
+         --data "dbName=${dataset}&dbType=tdb"
+done
+
+wait


### PR DESCRIPTION
Hi!

This PR fix #10 

User can pass environment variables FUSEKI_DATASET_1 to create datasets at startup.

```bash
docker run  -p 3030:3030 -e FUSEKI_DATASET_1=database -e FUSEKI_DATASET_2=test -e ADMIN_PASSWORD=admin fuseki
```

![image](https://user-images.githubusercontent.com/18330770/49792517-3a6a3b00-fd33-11e8-9f3e-b084e84e8d72.png)



The `docker-entrypoint.sh` wait until the server is up, and use curl to post a http request to create the datasets.

I replaced wget to curl because I need curl and we don't need both.
