### PR TITLE
Replace Docker Java with OpenJDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ docker build -t jena-fuseki jena-fuseki
  
 ## Dockerfile overview
 
-The `Dockerfile`s for both images use the official [java:8-jre-alpine](https://hub.docker.com/r/_/java/) base image, which is based on 
-the [alpine](https://hub.docker.com/_/alpine/) image; this clocks in at about [40 MB](https://microbadger.com/images/java:8-jre-alpine)
+The `Dockerfile`s for both images use the official [openjdk:8-jre-alpine](https://hub.docker.com/r/_/openjdk/) base image, which is based on 
+the [alpine](https://hub.docker.com/_/alpine/) image; this clocks in at about [55 MB](https://microbadger.com/images/openjdk:8-jre-alpine)
 
 
 The `ENV` variables like `JENA_VERSION` and `FUSEKI_VERSION` determines which version of Jena and Fuseki are downloaded. Updating the version also requires updating the `JENA_SHA1` and `FUSEKI_SHA1` variables, which values

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -16,7 +16,7 @@
 
 #FROM alpine:3.4
 #RUN apk add --update openjdk8-jre pwgen bash wget ca-certificates && rm -rf /var/cache/apk/*
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 RUN apk add --update pwgen bash curl ca-certificates && rm -rf /var/cache/apk/*
 
 MAINTAINER Stian Soiland-Reyes <stain@apache.org>

--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -1,7 +1,7 @@
 # Jena Fuseki 2 docker image
 
 * Docker image: [stain/jena-fuseki](https://hub.docker.com/r/stain/jena-fuseki/)
-* Base images:  [java](https://hub.docker.com/r/_/java/):8-jre-alpine
+* Base images:  [openjdk](https://hub.docker.com/r/_/openjdk/):8-jre-alpine
 * Source: [Dockerfile](https://github.com/stain/jena-docker/blob/master/jena-fuseki/Dockerfile), [Apache Jena Fuseki](http://jena.apache.org/download/)
 
 [![Build Status](https://travis-ci.org/stain/jena-docker.svg)](https://travis-ci.org/stain/jena-docker)

--- a/jena/Dockerfile
+++ b/jena/Dockerfile
@@ -14,7 +14,7 @@
 #   limitations under the License.
 
 #FROM alpine:3.4
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 #RUN apk add --update --no-cache openjdk8-jre bash wget ca-certificates && rm -rf /var/cache/apk/*
 RUN apk add --update --no-cache bash wget ca-certificates && rm -rf /var/cache/apk/*
 MAINTAINER Stian Soiland-Reyes <stain@apache.org>

--- a/jena/README.md
+++ b/jena/README.md
@@ -1,7 +1,7 @@
 # Jena command line tools
 
 * Docker image: [stain/jena](https://hub.docker.com/r/stain/jena/)
-* Base images: [java](https://hub.docker.com/r/_/java/):8-jre-alpine
+* Base images: [openjdk](https://hub.docker.com/r/_/openjdk/):8-jre-alpine
 * Source: [Dockerfile](https://github.com/stain/jena-docker/blob/master/jena/Dockerfile), [Apache Jena](http://jena.apache.org/download/)
 
 


### PR DESCRIPTION
The Docker image java:8-jre-alpine is no longer maintained and is using Alpine 3.4 which has since gone EOL. openjdk:8-jre-alpine is based on Alpine 3.9 and is actively maintained. 

I haven't tested this extensively, however I haven't experienced any negative consequences in my environment going to a newer OpenJDK image with your Dockerfile.