### PR TITLE
version update 3.11/3.12

### DIFF
--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -25,8 +25,8 @@ MAINTAINER Stian Soiland-Reyes <stain@apache.org>
 
 # Update below according to https://jena.apache.org/download/ and
 # corresponding *.tar.gz.sha512 from https://www.apache.org/dist/jena/binaries/
-ENV FUSEKI_SHA512 e934431a4b76c347c71480c620b19263b46cde359d3da508acffbe92ef21168eea2a17478f68e4b583a55a4e3a8b0c6b0e1b558ee8eba54bd777b3909669e7da
-ENV FUSEKI_VERSION 3.12.0
+ENV FUSEKI_SHA512 1960d3e057cdcaaa0811b33b57b86145fb0fb675eee1a6dd2d27a111313689e70ba8fa36b9ca66784cf9130ae5753bf50e32e82d9e3a7bba2786a0fc4ae7f056
+ENV FUSEKI_VERSION 3.13.1
 # Tip: No need for https as we've coded the sha512 above
 ENV ASF_MIRROR_EU http://www.eu.apache.org/dist/
 ENV ASF_MIRROR_US http://www.us.apache.org/dist/

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -25,8 +25,8 @@ MAINTAINER Stian Soiland-Reyes <stain@apache.org>
 
 # Update below according to https://jena.apache.org/download/ and
 # corresponding *.tar.gz.sha512 from https://www.apache.org/dist/jena/binaries/
-ENV FUSEKI_SHA512 18018d262987673c2707e0f8daac407eb61dfc4a08015e19b72b1d682d1540eddf2507575b79a161b37f029da63a58d71ba7772c1b5b5fca80d845527a6f7a7a
-ENV FUSEKI_VERSION 3.11.0
+ENV FUSEKI_SHA512 e934431a4b76c347c71480c620b19263b46cde359d3da508acffbe92ef21168eea2a17478f68e4b583a55a4e3a8b0c6b0e1b558ee8eba54bd777b3909669e7da
+ENV FUSEKI_VERSION 3.12.0
 # Tip: No need for https as we've coded the sha512 above
 ENV ASF_MIRROR_EU http://www.eu.apache.org/dist/
 ENV ASF_MIRROR_US http://www.us.apache.org/dist/

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -55,10 +55,12 @@ RUN     (curl -sS --fail $ASF_MIRROR_EU/jena/binaries/apache-jena-fuseki-$FUSEKI
         rm fuseki.tar.gz* && \
         cd $FUSEKI_HOME && rm -rf fuseki.war
 
-# Test the install by testing it's ping resource
-RUN  /jena-fuseki/fuseki-server & \
-     sleep 10 && \
-     curl -sS --fail 'http://localhost:3030/$/ping' 
+# Test the install with it's ping resource
+RUN apk add --no-cache tini
+RUN /jena-fuseki/fuseki-server & \
+    /sbin/tini timeout -t 30 /bin/sh -c " \
+    echo 'waiting...'; sleep 5; \
+    until curl -sS --fail 'http://localhost:3030/$/ping'; do echo 'waiting...'; sleep 5; done"
 
 # No need to kill Fuseki as our shell will exit
 

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -57,7 +57,7 @@ RUN     (curl -sS --fail $ASF_MIRROR_EU/jena/binaries/apache-jena-fuseki-$FUSEKI
 
 # Test the install by testing it's ping resource
 RUN  /jena-fuseki/fuseki-server & \
-     sleep 4 && \
+     sleep 10 && \
      curl -sS --fail 'http://localhost:3030/$/ping' 
 
 # No need to kill Fuseki as our shell will exit

--- a/jena/Dockerfile
+++ b/jena/Dockerfile
@@ -21,8 +21,8 @@ MAINTAINER Stian Soiland-Reyes <stain@apache.org>
 
 # Update below according to https://jena.apache.org/download/ 
 # and checksum for .tar.gz
-ENV JENA_SHA512 7598dfe5d7f367949eb4361fc7d160fc908b67a1e3307e78f368ef8d95510f88819416c26b503bc8257c170e4d6b46b79c0634f1ba830ed2fa9782611187198e
-ENV JENA_VERSION 3.11.0
+ENV JENA_SHA512 d1eba835acd0d15f959dd403918e17bc7e44312d3788640ab6a0d3453b22105f40a2c5feea675137d2773db74e4ca15dd018ff16d8576e01fdceba81e36f04fa
+ENV JENA_VERSION 3.12.0
 # Tip: No need for https as we've coded the sha512 above
 ENV ASF_MIRROR_EU http://www.eu.apache.org/dist/
 ENV ASF_MIRROR_US http://www.us.apache.org/dist/


### PR DESCRIPTION
Hello,

I have encounter this issue: https://issues.apache.org/jira/browse/JENA-1663 with the current latest build. The problem seems to be fix in version 3.11 of jena-fuseki.

I'm building an image based on your work to ease my application installation that require 3.11 version at least.

I though it would be possible to pull request tags but it seems not.
Is it possible to publish following tags ? And process the build on hub.docker.com ?
- fuseki-3.11.0-1
- fuseki-3.12.0-1
- jena-3.11.0-1
- jena-3.12.0-1

Thanks