### PR TITLE
Add support for TDB2

### DIFF
--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -103,6 +103,15 @@ To restart a named container (it will remember the volume and port config)
 
     docker restart fuseki
 
+### Using TDB 2
+
+To use [TDB v2](https://jena.apache.org/documentation/tdb2/) you can pass the environment variable with `-e TDB=2`
+
+     docker run -p 3030:3030 -e TDB=2 stain/jena-fuseki
+
+If you do so, then you need to use the appropriate `tdbloader2` for your data, see below for more details.
+
+
 ## Upgrading Fuseki
 
 If you want to upgrade the Fuseki container named `fuseki` which use the data
@@ -171,6 +180,15 @@ graphs, see the `tdbloader` section below.
 admin password will be set before you have started Fuseki.
 You can either check the output of the data loading, or later override the
 password using `-e ADMIN_PASSWORD=pw123`.
+
+
+### Using the `tdbloader2` for TDB2
+
+Assume you have already the container running named `fuseki` you can execute
+
+    docker exec -it fuseki  /bin/bash -c 'tdbloader2 --loc chembl19  /staging/{cco.ttl.gz,void.ttl.gz}'
+
+
 
 
 ## Recognizing the dataset in Fuseki

--- a/jena-fuseki/docker-entrypoint.sh
+++ b/jena-fuseki/docker-entrypoint.sh
@@ -39,11 +39,11 @@ fi
 
 exec "$@" &
 
-TDB=''
-if [ -z ${TDB+x} ] && [ "${TDB}" = "2" ] ; then 
-  TDB='tdb2'
+TDB_VERSION=''
+if [ ! -z ${TDB+x} ] && [ "${TDB}" = "2" ] ; then 
+  TDB_VERSION='tdb2'
 else
-  TDB='tdb'
+  TDB_VERSION='tdb'
 fi
 
 # Wait until server is up
@@ -58,7 +58,7 @@ do
     curl -s 'http://localhost:3030/$/datasets'\
          -H "Authorization: Basic $(echo -n admin:${ADMIN_PASSWORD} | base64)" \
          -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8'\
-         --data "dbName=${dataset}&dbType=${TDB}"
+         --data "dbName=${dataset}&dbType=${TDB_VERSION}"
 done
 
 wait

--- a/jena-fuseki/docker-entrypoint.sh
+++ b/jena-fuseki/docker-entrypoint.sh
@@ -39,6 +39,13 @@ fi
 
 exec "$@" &
 
+TDB=''
+if [ -z ${TDB+x} ] && [ "${TDB}" = "2" ] ; then 
+  TDB='tdb2'
+else
+  TDB='tdb'
+fi
+
 # Wait until server is up
 while [[ $(curl -I http://localhost:3030 2>/dev/null | head -n 1 | cut -d$' ' -f2) != '200' ]]; do
   sleep 1s
@@ -51,7 +58,7 @@ do
     curl -s 'http://localhost:3030/$/datasets'\
          -H "Authorization: Basic $(echo -n admin:${ADMIN_PASSWORD} | base64)" \
          -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8'\
-         --data "dbName=${dataset}&dbType=tdb"
+         --data "dbName=${dataset}&dbType=${TDB}"
 done
 
 wait

--- a/jena-fuseki/tdbloader2
+++ b/jena-fuseki/tdbloader2
@@ -1,0 +1,17 @@
+#!/bin/bash
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+JVM_ARGS=${JVM_ARGS:--Xmx1200M}
+exec java $JVM_ARGS -cp $FUSEKI_HOME/fuseki-server.jar tdb2.tdbloader $@


### PR DESCRIPTION
This pull request introduces initial support for the [TDB2](https://jena.apache.org/documentation/tdb2/) storage engine.

It introduces a new environment variable `TDB` for the docker entrypoint, a new script `tdbloader2`, and updates the documentation to show how to use it.