### PR TITLE
Redirect stderr to stdout to check for keywords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ script:
   - docker run --name fuseki -p 127.0.0.1:3030:3030 -d jena-fuseki
   - sleep 8
   - docker logs fuseki
-  - docker logs fuseki | grep --quiet ^admin=
-  - docker logs fuseki | grep --quiet Started
+  - docker logs fuseki 2>&1 | grep --quiet ^admin=
+  - docker logs fuseki 2>&1 | grep --quiet Started
   - curl http://127.0.0.1:3030/ | grep --quiet Fuseki


### PR DESCRIPTION
We are checking certain keywords in the output of `docker logs`.

As they are written on different channels we combine them for checking.

Also see comments in #50 for details.

Link to successful Travis CI build: https://travis-ci.org/github/stain/jena-docker/builds/769551788