### PR TITLE
Fix section title in README.md

### DIFF
--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -238,8 +238,7 @@ and inspect `/fuseki` with the shell. Remember to restart fuseki afterwards:
 
     docker restart fuseki
 
-
-### Additional JARs on Fuseki classpath
+### Additional JARs on Fuseki classpath
 
 If you need to add additional JARs to the classpath, but do not want to 
 modify the volume `/fuseki`, then add the JARs to


### PR DESCRIPTION
There might be some special blank character in that title, that's causing it to render as plain text on GitHub UI. I copied the title above, and replaced the text. The preview displayed rendered the title correctly :+1: 