### PR TITLE
Moved clearing of password until after datasets are created

### DIFF
--- a/jena-fuseki/docker-entrypoint.sh
+++ b/jena-fuseki/docker-entrypoint.sh
@@ -42,7 +42,6 @@ if [ -n "$ADMIN_PASSWORD" ] ; then
   export ADMIN_PASSWORD
   envsubst '${ADMIN_PASSWORD}' < "$FUSEKI_BASE/shiro.ini" > "$FUSEKI_BASE/shiro.ini.$$" && \
     mv "$FUSEKI_BASE/shiro.ini.$$" "$FUSEKI_BASE/shiro.ini"
-  unset ADMIN_PASSWORD # Don't keep it in memory
   export ADMIN_PASSWORD
 fi
 
@@ -65,11 +64,14 @@ done
 printenv | egrep "^FUSEKI_DATASET_" | while read env_var
 do
     dataset=$(echo $env_var | egrep -o "=.*$" | sed 's/^=//g')
+    echo "Creating dataset $dataset"
     curl -s 'http://localhost:3030/$/datasets'\
          -H "Authorization: Basic $(echo -n admin:${ADMIN_PASSWORD} | base64)" \
          -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8'\
          --data "dbName=${dataset}&dbType=${TDB_VERSION}"
 done
+echo "Launching Fuseki..."
+unset ADMIN_PASSWORD # Don't keep it in memory
 
 # rejoin our exec
 wait


### PR DESCRIPTION
The entrypoint script was failing to add new datasets because the env variable for the admin password was being cleared too early, resulting in the CURL command returning a 401. 