### PR TITLE
also restrict GSP update

### DIFF
--- a/jena-fuseki/shiro.ini
+++ b/jena-fuseki/shiro.ini
@@ -42,6 +42,9 @@ admin=${ADMIN_PASSWORD}
 ## Sparql update is restricted
 /*/update/** = authcBasic,user[admin]
 
+## GSP update is restricted
+/*/data/** = authcBasic,user[admin]
+
 
 ## If you want simple, basic authentication user/password
 ## on the operations,


### PR DESCRIPTION
before this patch a GSP update, like the following, would work without authentication:

curl 'http://server:port/dataset/data?graph=SOMEGRAPH' -H 'Content-type: text/turtle' --data-binary @$./some.ttl

see here for more details:
https://jena.apache.org/documentation/fuseki2/fuseki-embedded.html#example-1