### PR TITLE
Upgraded Fuseki to 4.7 and run as non root

### DIFF
--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -21,15 +21,15 @@ ENV LANG C.UTF-8
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-       bash curl ca-certificates findutils coreutils gettext pwgen procps tini \
+    bash curl ca-certificates findutils coreutils gettext pwgen procps tini \
     ; \
     rm -rf /var/lib/apt/lists/*
 
 
 # Update below according to https://jena.apache.org/download/ 
 # and checksum for apache-jena-fuseki-4.x.x.tar.gz.sha512
-ENV FUSEKI_SHA512 21850b9d106d40962cb8358cf5731509ed9f38be7f47a0fc7e2fa22247d89faf7b4ef3ecb58cac590b7592b3b8340b80214ab7ca67b9d1231acb68df62b8bd3d
-ENV FUSEKI_VERSION 4.4.0
+ENV FUSEKI_SHA512 9646343a23c2563357207f559cb7437aa91b52d02b87e70d77b746b609e93ed0ad9dce06e072f864d53422946f24aa8ee60d9c594c1f82e8f2ab226eba56e474
+ENV FUSEKI_VERSION 4.7.0
 # No need for https due to sha512 checksums below
 ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
 ENV ASF_ARCHIVE http://archive.apache.org/dist/
@@ -55,17 +55,17 @@ WORKDIR /tmp
 RUN echo "$FUSEKI_SHA512  fuseki.tar.gz" > fuseki.tar.gz.sha512
 # Download/check/unpack/move in one go (to reduce image size)
 RUN     (curl --location --silent --show-error --fail --retry-connrefused --retry 3 --output fuseki.tar.gz ${ASF_MIRROR}jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz || \
-         curl --fail --silent --show-error --retry-connrefused --retry 3 --output fuseki.tar.gz $ASF_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz) && \
-        sha512sum -c fuseki.tar.gz.sha512 && \
-        tar zxf fuseki.tar.gz && \
-        mv apache-jena-fuseki* $FUSEKI_HOME && \
-        rm fuseki.tar.gz* && \
-        cd $FUSEKI_HOME && rm -rf fuseki.war && chmod 755 fuseki-server
+    curl --fail --silent --show-error --retry-connrefused --retry 3 --output fuseki.tar.gz $ASF_ARCHIVE/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz) && \
+    sha512sum -c fuseki.tar.gz.sha512 && \
+    tar zxf fuseki.tar.gz && \
+    mv apache-jena-fuseki* $FUSEKI_HOME && \
+    rm fuseki.tar.gz* && \
+    cd $FUSEKI_HOME && rm -rf fuseki.war && chmod 755 fuseki-server
 
 # Test the install by testing it's ping resource. 20s sleep because Docker Hub.
 RUN  $FUSEKI_HOME/fuseki-server & \
-     sleep 20 && \
-     curl -sS --fail 'http://localhost:3030/$/ping' 
+    sleep 20 && \
+    curl -sS --fail 'http://localhost:3030/$/ping' 
 
 # No need to kill Fuseki as our shell will exit after curl
 

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -86,12 +86,15 @@ RUN chmod 755 $FUSEKI_HOME/load.sh $FUSEKI_HOME/tdbloader $FUSEKI_HOME/tdbloader
 
 # Where we start our server from
 WORKDIR $FUSEKI_HOME
+RUN chown -R 10001:0 $FUSEKI_HOME && chmod -R og+rwx $FUSEKI_HOME
 
 # Make sure we start with empty /fuseki
 RUN rm -rf $FUSEKI_BASE
 VOLUME $FUSEKI_BASE
 
 EXPOSE 3030
-ENTRYPOINT ["/usr/bin/tini", "--", "/docker-entrypoint.sh"]
+USER 10001
+
+ENTRYPOINT ["/usr/bin/tini", "--", "sh", "/docker-entrypoint.sh"]
 CMD ["/jena-fuseki/fuseki-server"]
 


### PR DESCRIPTION
Hello,

I had to deploy fuseki on Openshift and choose your repository as base. I had to make the container run as non root else Openshift doesn't let it run. I also upgraded Fuseki. 

Thanks