### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker build -t jena-fuseki jena-fuseki
  
 ## Dockerfile overview
 
-The `Dockerfile`s for both images use the official [openjdk:11-jre-slim-buster](https://hub.docker.com/r/_/openjdk/) base image, which is [based on](https://github.com/docker-library/openjdk/blob/master/11/jre/slim/Dockerfile) the [`debian`](https://hub.docker.com/_/debian/):buster-slim image; this clocks in at about [69 MB](https://microbadger.com/images/openjdk:11-jre-slim-buster)
+The `Dockerfile`s for both images use the official [eclipse-temurin:17-jre-alpine](https://hub.docker.com/r/_/eclipse-temurin/) base image, which is based on the [`Apline`](https://hub.docker.com/_/alpine/):3.18.0 image; this clocks in at about 55 MB.
 
 The `ENV` variables like `JENA_VERSION` and `FUSEKI_VERSION` determines which version of Jena and Fuseki are downloaded. Updating the version also requires updating the `JENA_SHA512` and `FUSEKI_SHA512` variables, which values should match the official Jena download `.tar.gz.sha512` hashes, as approved in their release `[VOTE]` emails.
 

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ To minimize layer size, there's a single `RUN` with `curl`, `sha512sum`, `tar zx
 Some files from the Apache Jena distributions are stripped, e.g. javadocs and the `fuseki.war` file.
 
 The Fuseki image includes some [helper scripts](jena-fuseki/load.sh) to do [tdb loading](https://jena.apache.org/documentation/tdb/commands.html) using `fuseki-server.jar`.
-In addition Fuseki has a [`docker-entrypoint.sh`](https://github.com/stain/jena-docker/blob/master/jena-fuseki/docker-entrypoint.sh) that populates `shiro.ini` with the password provided as `-e ADMIN_PASSWORD` to Docker, or with a new randomly generated password that is printed the first time.
+In addition, Fuseki has a [`docker-entrypoint.sh`](https://github.com/stain/jena-docker/blob/master/jena-fuseki/docker-entrypoint.sh) that populates `shiro.ini` with the password provided as `-e ADMIN_PASSWORD` to Docker, or with a new randomly generated password that is printed the first time.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `Dockerfile`s for both images use the official [openjdk:11-jre-slim-buster](
 
 The `ENV` variables like `JENA_VERSION` and `FUSEKI_VERSION` determines which version of Jena and Fuseki are downloaded. Updating the version also requires updating the `JENA_SHA512` and `FUSEKI_SHA512` variables, which values should match the official Jena download `.tar.gz.sha512` hashes, as approved in their release `[VOTE]` emails.
 
-The `ASF_MIRROR` use <http://www.apache.org/dyn/mirrors/mirrors.cgi> that redirect to a local mirror, with a fallback to the `ASF_ARCHIVE` <http://archive.apache.org/dist/> for older versions. Note that due to subsequent sha512 checking these accessed with `http` rather than `https`.
+The `ASF_MIRROR` use <http://www.apache.org/dyn/mirrors/mirrors.cgi> that redirect to a local mirror, with a fallback to the `ASF_ARCHIVE` <http://archive.apache.org/dist/> for older versions.
 
 To minimize layer size, there's a single `RUN` with `curl`, `sha512sum`, `tar zxf` and `mv` - thus the temporary files during download and extraction are not part of the final image.
 

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -82,17 +82,22 @@ COPY tdbloader2 $FUSEKI_HOME/
 RUN chmod 755 $FUSEKI_HOME/load.sh $FUSEKI_HOME/tdbloader $FUSEKI_HOME/tdbloader2
 #VOLUME /staging
 
+# Create a fuseki user and group
+RUN addgroup -S fuseki && \
+    adduser -G fuseki -S -D -H fuseki
 
 # Where we start our server from
 WORKDIR $FUSEKI_HOME
-RUN chown -R 10001:0 $FUSEKI_HOME && chmod -R og+rwx $FUSEKI_HOME
+RUN chown -R fuseki:fuseki $FUSEKI_HOME
 
 # Make sure we start with empty /fuseki
-RUN rm -rf $FUSEKI_BASE
+RUN mkdir -p $FUSEKI_BASE; \
+    rm -rf $FUSEKI_BASE/*; \
+    chown -R fuseki:fuseki $FUSEKI_BASE
 VOLUME $FUSEKI_BASE
 
 EXPOSE 3030
-USER 10001
+USER fuseki
 
 ENTRYPOINT ["/usr/bin/tini", "--", "sh", "/docker-entrypoint.sh"]
 CMD ["/jena-fuseki/fuseki-server"]

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 
 # Update below according to https://jena.apache.org/download/ 
 # and checksum for apache-jena-fuseki-4.x.x.tar.gz.sha512
-ENV FUSEKI_SHA512 9646343a23c2563357207f559cb7437aa91b52d02b87e70d77b746b609e93ed0ad9dce06e072f864d53422946f24aa8ee60d9c594c1f82e8f2ab226eba56e474
-ENV FUSEKI_VERSION 4.7.0
+ENV FUSEKI_SHA512 78074d87d4c022ef7e89b8394d2b14ead447a9201d52795d8c9adab0e03341cffc883abb849dab340bbecfc18654e1d126a47d8936241e8e2f036b0d66294c7d
+ENV FUSEKI_VERSION 4.8.0
 # No need for https due to sha512 checksums below
 ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
 ENV ASF_ARCHIVE http://archive.apache.org/dist/

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -14,16 +14,14 @@
 #   limitations under the License.
 
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:17-jre-alpine
 MAINTAINER Stian Soiland-Reyes <stain@apache.org>
 
 ENV LANG C.UTF-8
 RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-    bash curl ca-certificates findutils coreutils gettext pwgen procps tini \
-    ; \
-    rm -rf /var/lib/apt/lists/*
+    apk -U upgrade; \
+    apk add bash curl ca-certificates findutils coreutils gettext pwgen procps tini; \
+    rm -rf /var/cache/apk/*
 
 
 # Update below according to https://jena.apache.org/download/ 
@@ -99,6 +97,6 @@ VOLUME $FUSEKI_BASE
 EXPOSE 3030
 USER fuseki
 
-ENTRYPOINT ["/usr/bin/tini", "--", "sh", "/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "sh", "/docker-entrypoint.sh"]
 CMD ["/jena-fuseki/fuseki-server"]
 

--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -30,9 +30,8 @@ RUN set -eux; \
 # and checksum for apache-jena-fuseki-4.x.x.tar.gz.sha512
 ENV FUSEKI_SHA512 78074d87d4c022ef7e89b8394d2b14ead447a9201d52795d8c9adab0e03341cffc883abb849dab340bbecfc18654e1d126a47d8936241e8e2f036b0d66294c7d
 ENV FUSEKI_VERSION 4.8.0
-# No need for https due to sha512 checksums below
-ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
-ENV ASF_ARCHIVE http://archive.apache.org/dist/
+ENV ASF_MIRROR https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
+ENV ASF_ARCHIVE https://archive.apache.org/dist/
 
 LABEL org.opencontainers.image.url https://github.com/stain/jena-docker/tree/master/jena-fuseki
 LABEL org.opencontainers.image.source https://github.com/stain/jena-docker/

--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -162,7 +162,7 @@ computer:
     docker run --volumes-from fuseki-data -v /home/stain/ops/chembl19:/staging \
        stain/jena-fuseki ./load.sh chembl19 cco.ttl.gz void.ttl.gz
 
-**Tip:** You might find it benefitial to run data loading from the data staging
+**Tip:** You might find it beneficial to run data loading from the data staging
 directory in order to use tab-completion etc. without exposing the path on the
 host. The `./load.sh` will expand patterns like `*.ttl` - you might have to
 use single quotes (e.g. `'*.ttl'`) on the host to avoid them being expanded
@@ -234,7 +234,7 @@ If you need to modify Fuseki's configuration further, you can use the equivalent
 
     docker run --volumes-from fuseki-data -it ubuntu bash
 
-and inspect `/fuseki` with the shell. Remember to restart fuseki afterwards:
+and inspect `/fuseki` with the shell. Remember to restart fuseki afterward:
 
     docker restart fuseki
 

--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -8,7 +8,7 @@
 
 [![](https://images.microbadger.com/badges/image/stain/jena-fuseki.svg)](https://microbadger.com/images/stain/jena-fuseki "stain/jena-fuseki")
 
-[![](https://images.microbadger.com/badges/version/stain/jena-fuseki:4.0.0.svg)](https://github.com/stain/jena-docker/ "Jena Fuseki 4.0.0")
+[![](https://images.microbadger.com/badges/version/stain/jena-fuseki:4.8.0.svg)](https://github.com/stain/jena-docker/ "Jena Fuseki 4.8.0")
 
 
 This is a [Docker](https://www.docker.com/) image for running

--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -1,7 +1,7 @@
 # Jena Fuseki docker image
 
 * Docker image: [stain/jena-fuseki](https://hub.docker.com/r/stain/jena-fuseki/)
-* Base images:  [openjdk](https://hub.docker.com/r/_/openjdk/):11-jre-slim-buster
+* Base images: [eclipse-temurin](https://hub.docker.com/r/_/eclipse-temurin/):17-jre-alpine
 * Source: [Dockerfile](https://github.com/stain/jena-docker/blob/master/jena-fuseki/Dockerfile), [Apache Jena Fuseki](https://jena.apache.org/download/)
 
 [![Build](https://github.com/stain/jena-docker/actions/workflows/main.yml/badge.svg)](https://github.com/stain/jena-docker/actions/workflows/main.yml)
@@ -28,9 +28,9 @@ Different licenses apply to files added by different Docker layers:
 * stain/jena-fuseki [Dockerfile](https://github.com/stain/jena-docker/blob/master/jena-fuseki/Dockerfile): [Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * Apache Jena (`/jena-fuseki` in the image): [Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
   See also: `docker run stain/jena-fuseki cat /jena-fuseki/NOTICE`
-* OpenJDK (`/usr/local/openjdk-11/` in the image): [GPL 2.0 with Classpath exception](https://openjdk.java.net/legal/gplv2+ce.html)
-  See `/usr/local/openjdk-11/legal/` in image
-* Debian GNU/Linux (rest of `/`): [GPL 3](http://www.gnu.org/licenses/gpl-3.0) and [compatible licenses](https://www.debian.org/legal/licenses/), see `/usr/share/*/license` in image
+* OpenJDK (`/opt/java/openjdk/` in the image): [GPL 2.0 with Classpath exception](https://openjdk.java.net/legal/gplv2+ce.html)
+  See `/opt/java/openjdk/legal/` in image
+* Alpine GNU/Linux (rest of `/`): [GPL 2](http://www.gnu.org/licenses/gpl-2.0) and [Alpine License Information](https://gitlab.alpinelinux.org/alpine/aports/-/issues/7423)
 
 
 ## Use

--- a/jena-fuseki/docker-entrypoint.sh
+++ b/jena-fuseki/docker-entrypoint.sh
@@ -56,7 +56,8 @@ else
 fi
 
 # Wait until server is up
-while [[ $(curl -I http://localhost:3030 2>/dev/null | head -n 1 | cut -d$' ' -f2) != '200' ]]; do
+echo "Waiting for Fuseki to finish starting up..."
+until $(curl --output /dev/null --silent --head --fail http://localhost:3030); do
   sleep 1s
 done
 
@@ -70,7 +71,7 @@ do
          -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8'\
          --data "dbName=${dataset}&dbType=${TDB_VERSION}"
 done
-echo "Launching Fuseki..."
+echo "Fuseki is available :-)"
 unset ADMIN_PASSWORD # Don't keep it in memory
 
 # rejoin our exec

--- a/jena/Dockerfile
+++ b/jena/Dockerfile
@@ -32,9 +32,8 @@ RUN set -eux; \
 # and checksum for apache-jena-4.x.x.tar.gz.sha512
 ENV JENA_SHA512 d6b8d271c612a53f4683eb9b2f76c213452fdc38eef7b5d56100cd2c0f4c3153d07757120b08a27dd5a8fd27b51bd573273be713befaa205edfa2957ec82b5e5
 ENV JENA_VERSION 4.8.0
-# No need for https due to sha512 checksums below
-ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
-ENV ASF_ARCHIVE http://archive.apache.org/dist/
+ENV ASF_MIRROR https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
+ENV ASF_ARCHIVE https://archive.apache.org/dist/
 
 LABEL org.opencontainers.image.url https://github.com/stain/jena-docker/tree/master/jena
 LABEL org.opencontainers.image.source https://github.com/stain/jena-docker/

--- a/jena/Dockerfile
+++ b/jena/Dockerfile
@@ -13,18 +13,16 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:17-jre-alpine
 
 MAINTAINER Stian Soiland-Reyes <stain@apache.org>
 
 ENV LANG C.UTF-8
 
 RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-       bash curl ca-certificates findutils coreutils procps \
-    ; \
-    rm -rf /var/lib/apt/lists/*
+    apk -U upgrade; \
+    apk add bash curl ca-certificates findutils coreutils procps; \
+    rm -rf /var/cache/apk/*
 
 
 

--- a/jena/Dockerfile
+++ b/jena/Dockerfile
@@ -29,9 +29,9 @@ RUN set -eux; \
 
 
 # Update below according to https://jena.apache.org/download/
-# and checksum for apache-jena-3.x.x.tar.gz.sha512
-ENV JENA_SHA512 20706c955faebd2f090ce741a3b836016b75f86135e658d5d8cceb00a36b800f4e6158238bbfb7751bf13c1167d60236c49fbc7e099cd2e4c357bf36fe3323ca
-ENV JENA_VERSION 4.0.0
+# and checksum for apache-jena-4.x.x.tar.gz.sha512
+ENV JENA_SHA512 d6b8d271c612a53f4683eb9b2f76c213452fdc38eef7b5d56100cd2c0f4c3153d07757120b08a27dd5a8fd27b51bd573273be713befaa205edfa2957ec82b5e5
+ENV JENA_VERSION 4.8.0
 # No need for https due to sha512 checksums below
 ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
 ENV ASF_ARCHIVE http://archive.apache.org/dist/

--- a/jena/README.md
+++ b/jena/README.md
@@ -9,7 +9,7 @@
 
 [![](https://images.microbadger.com/badges/image/stain/jena.svg)](https://microbadger.com/images/stain/jena "stain/jena")
 
-[![](https://images.microbadger.com/badges/version/stain/jena:4.0.0.svg)](https://github.com/stain/jena-docker/tree/master/jena "Jena 4.0.0")
+[![](https://images.microbadger.com/badges/version/stain/jena:4.8.0.svg)](https://github.com/stain/jena-docker/tree/master/jena "Jena 4.8.0")
 
 This docker image exposes the [Apache Jena](https://jena.apache.org/)
 command line tool [riot](https://jena.apache.org/documentation/io/#command-line-tools)

--- a/jena/README.md
+++ b/jena/README.md
@@ -1,7 +1,7 @@
 # Jena command line tools
 
 * Docker image: [stain/jena](https://hub.docker.com/r/stain/jena/)
-* Base images: [openjdk](https://hub.docker.com/r/_/openjdk/):11-jre-slim-buster
+* Base images: [eclipse-temurin](https://hub.docker.com/r/_/eclipse-temurin/):17-jre-alpine
 * Source: [Dockerfile](https://github.com/stain/jena-docker/blob/master/jena/Dockerfile), [Apache Jena](http://jena.apache.org/download/)
 
 
@@ -23,9 +23,9 @@ Different licenses apply to files added by different Docker layers:
 * stain/jena [Dockerfile](https://github.com/stain/jena-docker/blob/master/jena/Dockerfile): [Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * Apache Jena (`/jena` in the image): [Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
   See also: `docker run stain/jena cat /jena/NOTICE`
-* OpenJDK (`/usr/local/openjdk-11/` in the image): [GPL 2.0 with Classpath exception](https://openjdk.java.net/legal/gplv2+ce.html)
-  See `/usr/local/openjdk-11/legal/` in image
-* Debian GNU/Linux (rest of `/`): [GPL 3](http://www.gnu.org/licenses/gpl-3.0) and [compatible licenses](https://www.debian.org/legal/licenses/), see `/usr/share/*/license` in image
+* OpenJDK (`/opt/java/openjdk/` in the image): [GPL 2.0 with Classpath exception](https://openjdk.java.net/legal/gplv2+ce.html)
+  See `/opt/java/openjdk/legal/` in image
+* Alpine GNU/Linux (rest of `/`): [GPL 2](http://www.gnu.org/licenses/gpl-2.0) and [Alpine License Information](https://gitlab.alpinelinux.org/alpine/aports/-/issues/7423)
 
 
 
@@ -83,9 +83,9 @@ To executable multiple `riot` commands within a Docker container:
 
     docker run -it stain/jena sh
 
-Note that this image is based on a minimal
-[Debian GNU/Linux](https://www.debian.org/) installation. You can use
-the `apt` command to install additional tools.
+Note that this image is based on an
+[Alpine Linux](https://www.debian.org/) installation. You can use
+the `apk` command to install additional tools.
 
 
 ## Other command line tools


### PR DESCRIPTION
Updates:
1. Jena and Fuseki to 4.8.0.
2. Java to LTS 17.
3. Debian to Alpine (as a consequence of updating to Java LTS 17 from eclipse-temurin project).