### PR TITLE
Updated job image and action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build images
         run: |
           docker build -t jena jena


### PR DESCRIPTION
Runner does not work anymore since Ubuntu 20 is deprecated (more information [here](https://github.com/actions/runner-images/issues/11101))
https://github.com/stain/jena-docker/pull/87/checks

Also, it would be nice to accept the PRs that update the Jena version.