### PR TITLE
use TDB2

### DIFF
--- a/jena-fuseki/load.sh
+++ b/jena-fuseki/load.sh
@@ -72,4 +72,4 @@ echo ""
 echo $files
 echo "#########"
 
-exec $FUSEKI_HOME/tdbloader $TDBLOADER_OPTS --loc=$FUSEKI_BASE/databases/$DB $files
+exec $FUSEKI_HOME/tdbloader2 $TDBLOADER_OPTS --loc=$FUSEKI_BASE/databases/$DB $files


### PR DESCRIPTION
it's been the new storage format for a while:
https://jena.apache.org/documentation/tdb2/

and TDB1 was deprecated in Jena 5.6.0