### PR TITLE
Add support for Docker secrets

### DIFF
--- a/jena-fuseki/README.md
+++ b/jena-fuseki/README.md
@@ -57,6 +57,23 @@ You can override the admin-password using the form
 `-e ADMIN_PASSWORD=pw123`:
 
     docker run -p 3030:3030 -e ADMIN_PASSWORD=pw123 stain/jena-fuseki
+    
+Alternatively, you can create a file with the password and use Docker secrets:
+
+```yaml
+services:
+  fuseki:
+    image: stain/jena-fuseki
+    ports:
+      - "3030:3030"
+    secrets:
+      - admin_password
+secrets:
+    admin_password:
+        file: ./admin_password.txt
+```
+
+You can also define the secret inline, if you wish.
 
 To specify Java settings such as the amount of memory to allocate for the
 heap (default: 1200 MiB), set the `JVM_ARGS` environment with `-e`:

--- a/jena-fuseki/docker-entrypoint.sh
+++ b/jena-fuseki/docker-entrypoint.sh
@@ -22,7 +22,12 @@ if [ ! -f "$FUSEKI_BASE/shiro.ini" ] ; then
   echo "Initializing Apache Jena Fuseki"
   echo ""
   cp "$FUSEKI_HOME/shiro.ini" "$FUSEKI_BASE/shiro.ini"
-  if [ -z "$ADMIN_PASSWORD" ] ; then
+  if [ -f "/run/secrets/admin_password" ] ; then
+    ADMIN_PASSWORD=$(cat /run/secrets/admin_password)
+    echo "Password read from Docker secret:"
+    echo ""
+    echo "admin=$ADMIN_PASSWORD"  
+  elif [ -z "$ADMIN_PASSWORD" ] ; then
     ADMIN_PASSWORD=$(pwgen -s 15)
     echo "Randomly generated admin password:"
     echo ""


### PR DESCRIPTION
These changes should enable the use of Docker secrets for setting the admin password. 

All changes are in the `docker-entrypoint.sh` file and the README has been updated.

Please let me know if you'd like any changes! 