### PR TITLE
bump to 6.0.0

### DIFF
--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -15,7 +15,8 @@
 
 
 FROM eclipse-temurin:21-jre-alpine
-MAINTAINER Stian Soiland-Reyes <stain@apache.org>
+LABEL maintainer="Stian Soiland-Reyes <stain@apache.org>"
+
 
 ENV LANG C.UTF-8
 RUN set -eux; \
@@ -26,8 +27,8 @@ RUN set -eux; \
 
 # Update below according to https://jena.apache.org/download/ 
 # and checksum for apache-jena-fuseki-4.x.x.tar.gz.sha512
-ENV FUSEKI_SHA512 50d33937092e8120d57f503b6e96ef988894602aa060ff945ec3aecf0349b0b22250e158bb379d0300589653dc9d6f3e6eb2b9790b5125144108dd6f19dc41e6
-ENV FUSEKI_VERSION 5.1.0
+ENV FUSEKI_SHA512 8b14dcefade409bb4efd94e05291ea46d50508bf175f6f163f328d1d80183559a4c5b75806802283802a2879405a132b9b311e2277f784a784fa66ce4a9d8722
+ENV FUSEKI_VERSION 6.0.0
 ENV ASF_MIRROR https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
 ENV ASF_ARCHIVE https://archive.apache.org/dist/
 

--- a/jena/Dockerfile
+++ b/jena/Dockerfile
@@ -15,7 +15,7 @@
 
 FROM eclipse-temurin:21-jre-alpine
 
-MAINTAINER Stian Soiland-Reyes <stain@apache.org>
+LABEL maintainer="Stian Soiland-Reyes <stain@apache.org>"
 
 ENV LANG C.UTF-8
 
@@ -28,8 +28,8 @@ RUN set -eux; \
 
 # Update below according to https://jena.apache.org/download/
 # and checksum for apache-jena-4.x.x.tar.gz.sha512
-ENV JENA_SHA512 f426275591aaa5274a89cab2f2ee16623086c5f0c7669bda5b2cead90089497e57098885745fd88e3c7db75cbaac48fe58f84ec9cd2dbb937592ff2f0ef0f92e
-ENV JENA_VERSION 5.1.0
+ENV JENA_SHA512 c66b413f0c97e465c8a5a71f2718116134c65efa71205e136a42ad0ee6d39deece0dcbcc99801d806e4b60af5fe886c72eb53c77bc464fe9d2d0f1ba2d3ec1fe
+ENV JENA_VERSION 6.0.0
 ENV ASF_MIRROR https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
 ENV ASF_ARCHIVE https://archive.apache.org/dist/
 


### PR DESCRIPTION
updates version to 6.00
updates hash for jena and fuseki
fixes dockerfile deprecation
